### PR TITLE
fix nem cosignature embedding

### DIFF
--- a/nem/multisig/multisig.cats
+++ b/nem/multisig/multisig.cats
@@ -7,6 +7,9 @@ struct Cosignature
 
 	inline Transaction
 
+	# multisig transaction hash outer size
+	multisig_transaction_hash_outer_size = make_reserved(int32, 36)
+
 	# [__value__] multisig transaction hash
 	#
 	# [size] multisig transaction hash size
@@ -14,7 +17,7 @@ struct Cosignature
 
 	# [__value__] multisig account address
 	#
-	# [size] multisig account size
+	# [size] multisig account address size
 	multisig_account_address = inline SizePrefixedAddress
 
 # binary layout for a multisig transaction

--- a/nem/types.cats
+++ b/nem/types.cats
@@ -18,7 +18,7 @@ inline struct SizePrefixedAddress
 # binary layout for a size prefixed 32-byte hash
 inline struct SizePrefixedHash256
 	# hash size
-	size = make_reserved(uint32, 40)
+	size = make_reserved(uint32, 32)
 
 	# hash value
 	__value__ = Hash256


### PR DESCRIPTION
nem cosignature is using wrong hash size and missing outer hash size