### PR TITLE
fix: mosaic levy sentinel to be 0x00000000

### DIFF
--- a/nem/mosaic/mosaic_definition.cats
+++ b/nem/mosaic/mosaic_definition.cats
@@ -65,7 +65,7 @@ struct MosaicDefinition
 	levy_size = uint32
 
 	# optional levy that is applied to transfers of this mosaic
-	levy = MosaicLevy if 0xFFFFFFFF not equals levy_size
+	levy = MosaicLevy if 0x00000000 not equals levy_size
 
 # binary layout for an importance transfer transaction
 struct MosaicDefinitionTransaction


### PR DESCRIPTION
To improve, how can levy_size be calculated from the levy field/object instead of user-provided?